### PR TITLE
Added vs code setup files and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,40 @@ Given that we have a base image with ROS installed, we will create another image
 For doing that, navigate to Scripts/Galactic/Projects/Turtlebot3 and simply build the image from the Dockerfile using the following command:
 
 `docker build -t turtlebot3_galactic .`
+
+## 5. Using Visual Studio Code
+
+If you would like to use VS Code as a development enviornment, there is an excelent integration with Docker that is recommended. Follow these steps to set up a workspace for VS Code and Docker.
+
+### 5.1. Install VS Code and devcontainer extension
+
+1. Run the following command in a terminal to install vs code
+
+`sudo snap install --classic code # or code-insiders`
+
+2. Open vs code and press ctrl+shift+x
+
+3. type "Dev Containers" and download the extension
+
+### 5.1. Create a workspace folder and copy boilerplate files
+
+Create a workspace folder where you would like your project and copy the .devcontainer folder from Scripts/Galactic/VSCode into it.
+
+ex.
+
+1. `cd ~`
+
+2. `mkdir myworkspace`
+
+3. `cp ./ROS-DOCKER/Scripts/Galactic/VSCode/.devcontainer ./myworkspace`
+
+### 5.2. Open the folder in a Docker container
+
+1. Open the workspace folder in vs code.
+
+2. Press ctrl+shift+P and type "Dev Containers: Open Folder in Container" and press enter
+
+3. The VS Code window should reload and you are now working in a docker container!
+
+> [!TIP]
+>- You can open more terminals with ctrl+shift+`

--- a/Scripts/VSCode/.devcontainer/Dockerfile
+++ b/Scripts/VSCode/.devcontainer/Dockerfile
@@ -1,0 +1,28 @@
+FROM modelling_ros AS base
+
+#Basic updates
+RUN apt-get update
+RUN apt-get update --fix-missing
+RUN apt-get upgrade -y
+RUN apt-get dist-upgrade -y
+
+# Base ROS libraries
+RUN apt-get install ghostscript -y
+RUN apt-get install -y \
+        python3-colcon-common-extensions \
+        ros-$ROS_DISTRO-hardware-interface \
+        ros-$ROS_DISTRO-ament-cmake-clang-format \
+        usbutils \
+        fdisk \
+        python3-wstool \
+        python3-rosdep \
+        ninja-build \
+        stow \
+        ros-$ROS_DISTRO-cartographer \
+        ros-$ROS_DISTRO-cartographer-ros \
+        ros-$ROS_DISTRO-navigation2 \
+        ros-$ROS_DISTRO-nav2-bringup \
+        ros-$ROS_DISTRO-joint-state-publisher* \
+        ros-$ROS_DISTRO-robot-localization* && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/Scripts/VSCode/.devcontainer/devcontainer.json
+++ b/Scripts/VSCode/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+    "name": "ROS2 Galactic Dev Environment",
+    "dockerFile": "Dockerfile",
+    "workspaceFolder": "/workspace",
+    "mounts": [
+      "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached"
+    ],
+    "runArgs": [
+      "--gpus=all",
+      "--net=host",
+      "--privileged",
+      "--env=DISPLAY=${env:DISPLAY}"
+    ],
+    "remoteUser": "root"
+}


### PR DESCRIPTION
Using docker containers with the vs code extension allows for fast-paced development. You can clone a repository to your machine, open it with the container using the devcontainer.json to automatically mount the folder, and proceed to debug using the development environment. This workflow also protects against loss of work in the event you close the container without pushing your repository as the work is saved to your host machine.